### PR TITLE
Create appinstance into a new package to hold application context

### DIFF
--- a/app/appinstance/appinstance.go
+++ b/app/appinstance/appinstance.go
@@ -1,0 +1,15 @@
+package appinstance
+
+import (
+	"api.default.indicoinnovation.pt/config"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Application struct {
+	Config *config.Config
+	DB     *pgxpool.Pool
+	Server *fiber.App
+}
+
+var Data *Application

--- a/clients/google/pubsub/pubsub.go
+++ b/clients/google/pubsub/pubsub.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"api.default.indicoinnovation.pt/adapters/logging"
+	"api.default.indicoinnovation.pt/app/appinstance"
 	"api.default.indicoinnovation.pt/entity"
-	"api.default.indicoinnovation.pt/pkg/app"
 	"api.default.indicoinnovation.pt/pkg/helpers"
 	"cloud.google.com/go/pubsub"
 )
@@ -13,7 +13,7 @@ import (
 func New() (context.Context, *pubsub.Client) {
 	ctx := context.Background()
 
-	client, err := pubsub.NewClient(ctx, app.Inst.Config.GcpProjectID)
+	client, err := pubsub.NewClient(ctx, appinstance.Data.Config.GcpProjectID)
 	if err != nil {
 		logging.Log(&entity.LogDetails{
 			Message: "error to create new pubsub client",

--- a/clients/google/storage/storage.go
+++ b/clients/google/storage/storage.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"api.default.indicoinnovation.pt/adapters/logging"
+	"api.default.indicoinnovation.pt/app/appinstance"
 	"api.default.indicoinnovation.pt/config/constants"
 	"api.default.indicoinnovation.pt/entity"
-	"api.default.indicoinnovation.pt/pkg/app"
 	"cloud.google.com/go/storage"
 )
 
@@ -32,14 +32,14 @@ func SignedURL(object string, srcFolder string) (string, error) {
 	_, client := New()
 	defer client.Close()
 
-	finalObject := fmt.Sprintf("%s/%s/%s", app.Inst.Config.StorageBaseFolder, srcFolder, object)
+	finalObject := fmt.Sprintf("%s/%s/%s", appinstance.Data.Config.StorageBaseFolder, srcFolder, object)
 
 	opts := &storage.SignedURLOptions{
 		Method:  "GET",
 		Expires: time.Now().UTC().Add(constants.SignedURLExp * time.Minute),
 	}
 
-	url, err := client.Bucket(app.Inst.Config.StorageBucket).SignedURL(finalObject, opts)
+	url, err := client.Bucket(appinstance.Data.Config.StorageBucket).SignedURL(finalObject, opts)
 	if err != nil {
 		go logging.Log(&entity.LogDetails{
 			Message: "error to retrieve google storage signed url",
@@ -59,8 +59,8 @@ func SignedURL(object string, srcFolder string) (string, error) {
 func Upload(object string, dstFolder string, reader io.Reader, public bool) error {
 	ctx, client := New()
 
-	bucket := client.Bucket(app.Inst.Config.StorageBucket)
-	blob := bucket.Object(fmt.Sprintf("%s/%s/%s", app.Inst.Config.StorageBaseFolder, dstFolder, object))
+	bucket := client.Bucket(appinstance.Data.Config.StorageBucket)
+	blob := bucket.Object(fmt.Sprintf("%s/%s/%s", appinstance.Data.Config.StorageBaseFolder, dstFolder, object))
 	writer := blob.NewWriter(ctx)
 
 	if _, err := io.Copy(writer, reader); err != nil {

--- a/clients/mailgun/mailgun.go
+++ b/clients/mailgun/mailgun.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 
 	"api.default.indicoinnovation.pt/adapters/logging"
+	"api.default.indicoinnovation.pt/app/appinstance"
 	"api.default.indicoinnovation.pt/config/constants"
 	"api.default.indicoinnovation.pt/entity"
-	"api.default.indicoinnovation.pt/pkg/app"
 	"api.default.indicoinnovation.pt/pkg/helpers"
 	requestsnippet "github.com/indicoinnovation/go-request-snippet"
 )
@@ -28,8 +28,8 @@ type mailgunResponse struct {
 
 func New() *Mailgun {
 	return &Mailgun{
-		APIHost: fmt.Sprintf("https://api.mailgun.net/v3/%s/messages", app.Inst.Config.MailGunDomain),
-		APIKey:  fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("api:"+app.Inst.Config.MailGunKey))),
+		APIHost: fmt.Sprintf("https://api.mailgun.net/v3/%s/messages", appinstance.Data.Config.MailGunDomain),
+		APIKey:  fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("api:"+appinstance.Data.Config.MailGunKey))),
 	}
 }
 
@@ -74,7 +74,7 @@ func (mailgun *Mailgun) Send(to string, messageAttr *entity.MessageAttributes) {
 	}
 
 	emailData := map[string]string{
-		"from":    fmt.Sprintf("%s <%s>", app.Inst.Config.EmailSenderLabel, app.Inst.Config.EmailSenderAddress),
+		"from":    fmt.Sprintf("%s <%s>", appinstance.Data.Config.EmailSenderLabel, appinstance.Data.Config.EmailSenderAddress),
 		"to":      to,
 		"subject": messageAttr.Subject,
 		"html":    content,

--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
-import "api.default.indicoinnovation.pt/pkg/app"
+import (
+	"api.default.indicoinnovation.pt/app/appinstance"
+	"api.default.indicoinnovation.pt/pkg/app"
+)
 
 func main() {
 	app.ApplicationInit()
-	defer app.Inst.DB.Close()
+	defer appinstance.Data.DB.Close()
 
-	app.Inst.Server = route()
+	appinstance.Data.Server = route()
 
 	// Listening to Server
 	app.Setup()

--- a/route.go
+++ b/route.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"time"
 
+	"api.default.indicoinnovation.pt/app/appinstance"
 	"api.default.indicoinnovation.pt/config/constants"
 	"api.default.indicoinnovation.pt/entity"
 	"api.default.indicoinnovation.pt/handler/health"
 	"api.default.indicoinnovation.pt/middleware"
-	"api.default.indicoinnovation.pt/pkg/app"
 	"api.default.indicoinnovation.pt/pkg/helpers"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/compress"
@@ -26,21 +26,21 @@ func route() *fiber.App {
 		allowedOrigins += fmt.Sprintf(", %s", constants.AllowedStageOrigins)
 	}
 
-	app.Inst.Server.Use(logger.New())
-	app.Inst.Server.Use(recover.New())
-	app.Inst.Server.Use(favicon.New())
-	app.Inst.Server.Use(cors.New(cors.Config{
+	appinstance.Data.Server.Use(logger.New())
+	appinstance.Data.Server.Use(recover.New())
+	appinstance.Data.Server.Use(favicon.New())
+	appinstance.Data.Server.Use(cors.New(cors.Config{
 		AllowMethods: constants.AllowedMethods,
 		AllowOrigins: allowedOrigins,
 		AllowHeaders: constants.AllowedHeaders,
 	}))
-	app.Inst.Server.Use(middleware.ValidateContentType())
-	app.Inst.Server.Use(middleware.SecurityHeaders())
-	app.Inst.Server.Use(compress.New(compress.Config{
+	appinstance.Data.Server.Use(middleware.ValidateContentType())
+	appinstance.Data.Server.Use(middleware.SecurityHeaders())
+	appinstance.Data.Server.Use(compress.New(compress.Config{
 		Level: compress.LevelBestCompression,
 	}))
 
-	apiGroup := app.Inst.Server.Group("/api")
+	apiGroup := appinstance.Data.Server.Group("/api")
 	apiGroup.Use(limiter.New(limiter.Config{
 		Next: func(c *fiber.Ctx) bool {
 			return helpers.Contains(constants.AllowedUnthrottledIPs, c.IP())
@@ -66,5 +66,5 @@ func route() *fiber.App {
 
 	// Put auth required routes here
 
-	return app.Inst.Server
+	return appinstance.Data.Server
 }


### PR DESCRIPTION
It will avoid circular imports and make a cleaner way to hold context data.